### PR TITLE
add method to interface for getting all future visible releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 5.6
   - 7.0
   - hhvm
-  - nightly
 
 install: composer install --dev
 script: vendor/phpunit/phpunit/phpunit -c phpunit.xml --coverage-clover build/logs/clover.xml

--- a/src/Release/Gateway/ReleaseGateway.php
+++ b/src/Release/Gateway/ReleaseGateway.php
@@ -37,5 +37,10 @@ interface ReleaseGateway
      * @return bool
      */
     public function editRelease( $releaseId, $releaseName, $releaseUrl );
+
+    /**
+     * @return Release[]
+     */
+    public function getAllFutureVisibleReleases();
 }
 //EOF ReleaseGateway.php

--- a/test/Release/Gateway/ConfigurableVisibilityReleaseGatewayMock.php
+++ b/test/Release/Gateway/ConfigurableVisibilityReleaseGatewayMock.php
@@ -63,4 +63,12 @@ class ConfigurableVisibilityReleaseGatewayMock implements ReleaseGateway
     {
         return false;
     }
+
+    /**
+     * @return Release[]
+     */
+    public function getAllFutureVisibleReleases()
+    {
+        return [];
+    }
 }

--- a/test/Release/Gateway/DummyReleaseGateway.php
+++ b/test/Release/Gateway/DummyReleaseGateway.php
@@ -51,4 +51,12 @@ class DummyReleaseGateway implements ReleaseGateway
     {
         return false;
     }
+
+    /**
+     * @return Release[]
+     */
+    public function getAllFutureVisibleReleases()
+    {
+        return [];
+    }
 }

--- a/test/Release/Gateway/MockReleaseGateway.php
+++ b/test/Release/Gateway/MockReleaseGateway.php
@@ -64,4 +64,12 @@ class MockReleaseGateway implements ReleaseGateway
     {
         return false;
     }
+
+    /**
+     * @return Release[]
+     */
+    public function getAllFutureVisibleReleases()
+    {
+        return $this->releases;
+    }
 }

--- a/test/Release/Gateway/SpyReleaseGateway.php
+++ b/test/Release/Gateway/SpyReleaseGateway.php
@@ -86,6 +86,14 @@ class SpyReleaseGateway implements ReleaseGateway
         }
         return false;
     }
+
+    /**
+     * @return Release[]
+     */
+    public function getAllFutureVisibleReleases()
+    {
+        return [];
+    }
 }
 
 //EOF SpyReleaseGateway.php

--- a/test/Release/Gateway/StubReleaseGateway.php
+++ b/test/Release/Gateway/StubReleaseGateway.php
@@ -51,4 +51,12 @@ class StubReleaseGateway implements ReleaseGateway
     {
         return false;
     }
+
+    /**
+     * @return Release[]
+     */
+    public function getAllFutureVisibleReleases()
+    {
+        return [];
+    }
 }


### PR DESCRIPTION
I was bored and wanted to do some php

Adds a method for getting all future, and visible releases, this will probably be useful if the decision ever comes to have future releases visible for longer (i.e. we have something we want people to try out for longer)
